### PR TITLE
Moved around_transition out of protected block

### DIFF
--- a/lib/state_machine/integrations/active_model.rb
+++ b/lib/state_machine/integrations/active_model.rb
@@ -397,6 +397,11 @@ module StateMachine
         object.errors.clear if supports_validations?
       end
       
+      # Runs state events around the object's validation process
+      def around_validation(object)
+        object.class.state_machines.transitions(object, action, :after => false).perform { yield }
+      end
+      
       protected
         # Whether observers are supported in the integration.  Only true if
         # ActiveModel::Observer is available.
@@ -507,11 +512,6 @@ module StateMachine
         # :validation event
         def define_validation_hook
           owner_class.set_callback(:validation, :around, self, :prepend => true)
-        end
-        
-        # Runs state events around the object's validation process
-        def around_validation(object)
-          object.class.state_machines.transitions(object, action, :after => false).perform { yield }
         end
         
         # Creates a new callback in the callback chain, always inserting it


### PR DESCRIPTION
cherry-pick commit from
https://github.com/pluginaweek/state_machine/pull/275
so it will work with rails 4.1.
